### PR TITLE
Allow to run legacy PostgreSQL setup for Sylius < 1.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
             matrix:
                 php: [ "8.1" ]
                 symfony: [ "^5.4" ]
-                sylius: [ "^1.11" ]
+                sylius: [ "1.12", "1.13" ]
                 node: [ "16.x" ]
                 mysql: [ "8.0" ]
 
@@ -45,6 +45,7 @@ jobs:
                     database_version: ${{ matrix.mysql }}
                     php_version: ${{ matrix.php }}
                     symfony_version: ${{ matrix.symfony }}
+                    legacy_postgresql_setup: ${{ matrix.sylius == '1.13' && 'no' || 'yes' }}
 
             -   name: Run Behat
                 run: |
@@ -53,19 +54,20 @@ jobs:
 
 ## Inputs
 
-| Name                 | Description                                                                                                | Default                                               | Required to be explicitly defined |
-|----------------------|------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|-----------------------------------|
-| `build_type`         | Type of the build. Possible values: `sylius` (Sylius/Sylius repo), `app` (Sylius-Standard based), `plugin` | `app`                                                 | no                                |
-| `cache_key`          | A cache key to be used                                                                                     |                                                       | No                                |
-| `cache_restore_key`  | A cache restore key to be used                                                                             |                                                       | No                                |
-| `e2e`                | Whether prepare the test application for e2e tests                                                         | `no`                                                  | No                                |
-| `e2e_js`             | Whether prepare the test application for e2e tests with JS                                                 | `no`                                                  | No                                |
-| `database`           | A database engine to be used. Possible values: `mysql`, `mariadb`, `postgresql`                            | `mysql`                                               | Yes                               |
-| `database_version`   | MySQL version to be used                                                                                   | `8.0`                                                 | No                                |
-| `php_version`        | PHP version to be used                                                                                     |                                                       | Yes                               |
-| `php_extensions`     | PHP extensions to be installed                                                                             | intl, gd, opcache, mysql, pdo_mysql, pgsql, pdo_pgsql | No                                |
-| `php_tools`          | PHP tools to be installed                                                                                  | symfony                                               | No                                |
-| `symfony_version`    | Symfony version to be used                                                                                 |                                                       | Yes                               |
-| `sylius_version`     | Sylius version to be used                                                                                  | by default no version restriction is applied          | no                                |
-| `sylius_integration` | Parameter only for our internal purposes, where we test Sylius in different configurations                 | empty                                                 | No                                |
-| `node_version`       | Node version to be used                                                                                    | `16.x`                                                | No                                |
+| Name                      | Description                                                                                                | Default                                               | Required to be explicitly defined |
+|---------------------------|------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|-----------------------------------|
+| `build_type`              | Type of the build. Possible values: `sylius` (Sylius/Sylius repo), `app` (Sylius-Standard based), `plugin` | `app`                                                 | no                                |
+| `cache_key`               | A cache key to be used                                                                                     |                                                       | No                                |
+| `cache_restore_key`       | A cache restore key to be used                                                                             |                                                       | No                                |
+| `e2e`                     | Whether prepare the test application for e2e tests                                                         | `no`                                                  | No                                |
+| `e2e_js`                  | Whether prepare the test application for e2e tests with JS                                                 | `no`                                                  | No                                |
+| `database`                | A database engine to be used. Possible values: `mysql`, `mariadb`, `postgresql`                            | `mysql`                                               | Yes                               |
+| `database_version`        | MySQL version to be used                                                                                   | `8.0`                                                 | No                                |
+| `legacy_postgresql_setup` | Whether to use legacy PostgreSQL setup (before 1.13)                                                       | `no`                                                  | No                                |
+| `php_version`             | PHP version to be used                                                                                     |                                                       | Yes                               |
+| `php_extensions`          | PHP extensions to be installed                                                                             | intl, gd, opcache, mysql, pdo_mysql, pgsql, pdo_pgsql | No                                |
+| `php_tools`               | PHP tools to be installed                                                                                  | symfony                                               | No                                |
+| `symfony_version`         | Symfony version to be used                                                                                 |                                                       | Yes                               |
+| `sylius_version`          | Sylius version to be used                                                                                  | by default no version restriction is applied          | no                                |
+| `sylius_integration`      | Parameter only for our internal purposes, where we test Sylius in different configurations                 | empty                                                 | No                                |
+| `node_version`            | Node version to be used                                                                                    | `16.x`                                                | No                                |

--- a/action.yaml
+++ b/action.yaml
@@ -35,6 +35,10 @@ inputs:
     database_version:
         required: true
         description: "A database version to be used"
+    legacy_postgresql_setup:
+        required: false
+        description: "Whether to use legacy PostgreSQL setup (before 1.13)"
+        default: "no"
 
     # PHP
     php_version:
@@ -236,9 +240,20 @@ runs:
         #####################################################################
 
         -   name: Prepare application database
+            if: inputs.database != 'postgresql' || (inputs.database == 'postgresql' && inputs.legacy_postgresql_setup == 'no')
             run: |
                 bin/console doctrine:database:create --if-not-exists -vvv
                 bin/console doctrine:migrations:migrate -n -vvv
+            shell: bash
+            working-directory: "${{ env.application_dir }}"
+
+        -   name: Prepare application database (legacy)
+            if: inputs.database == 'postgresql' && inputs.legacy_postgresql_setup == 'yes'
+            run: |
+                bin/console doctrine:database:create --if-not-exists -vvv
+                bin/console doctrine:schema:up --force -vvv
+                bin/console doctrine:schema:validate
+                bin/console doctrine:migrations:sync-metadata-storage
             shell: bash
             working-directory: "${{ env.application_dir }}"
 


### PR DESCRIPTION
In `2.2` I'd like to allow to use the old way of setting up of PostgreSQL based on a parameter.